### PR TITLE
Add UEFI QR code application

### DIFF
--- a/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
+++ b/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
@@ -1,0 +1,229 @@
+#include <Uefi.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PrintLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+
+#include "QrCode.h"
+
+#define QUIET_ZONE_SIZE             2
+#define VENDOR_MAX_LENGTH           5
+#define INFO_BUFFER_LENGTH          64
+
+STATIC
+VOID
+PrepareVendorString(
+  OUT CHAR8       *Buffer,
+  IN  UINTN        BufferSize,
+  IN  CONST CHAR16 *Vendor
+  )
+{
+  if (BufferSize == 0) {
+    return;
+  }
+
+  if (Vendor == NULL) {
+    AsciiStrCpyS(Buffer, BufferSize, "UNK");
+    return;
+  }
+
+  RETURN_STATUS ConversionStatus = UnicodeStrToAsciiStrS(Vendor, Buffer, BufferSize);
+  if (RETURN_ERROR(ConversionStatus)) {
+    AsciiStrnCpyS(Buffer, BufferSize, "UNK", BufferSize - 1);
+  }
+
+  for (UINTN Index = 0; Buffer[Index] != '\0'; Index++) {
+    if (Buffer[Index] == ' ') {
+      Buffer[Index] = '_';
+    }
+  }
+}
+
+STATIC
+EFI_STATUS
+GetMemoryStatistics(
+  OUT UINT64 *TotalMemoryMb,
+  OUT UINTN  *DescriptorCount
+  )
+{
+  if (TotalMemoryMb == NULL || DescriptorCount == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  EFI_STATUS            Status;
+  EFI_MEMORY_DESCRIPTOR *MemoryMap = NULL;
+  UINTN                 MapSize = 0;
+  UINTN                 MapKey;
+  UINTN                 DescriptorSize = 0;
+  UINT32                DescriptorVersion;
+
+  Status = gBS->GetMemoryMap(&MapSize, MemoryMap, &MapKey, &DescriptorSize, &DescriptorVersion);
+  if (Status != EFI_BUFFER_TOO_SMALL) {
+    return Status;
+  }
+
+  MapSize += DescriptorSize * 4;
+  MemoryMap = AllocateZeroPool(MapSize);
+  if (MemoryMap == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = gBS->GetMemoryMap(&MapSize, MemoryMap, &MapKey, &DescriptorSize, &DescriptorVersion);
+  if (EFI_ERROR(Status)) {
+    FreePool(MemoryMap);
+    return Status;
+  }
+
+  UINT64 TotalPages = 0;
+  UINTN  Count = MapSize / DescriptorSize;
+  EFI_MEMORY_DESCRIPTOR *Descriptor = MemoryMap;
+  for (UINTN Index = 0; Index < Count; Index++) {
+    TotalPages += Descriptor->NumberOfPages;
+    Descriptor = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)Descriptor + DescriptorSize);
+  }
+
+  FreePool(MemoryMap);
+
+  *TotalMemoryMb = DivU64x32(TotalPages, 256);
+  *DescriptorCount = Count;
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+VOID
+RenderQuietRow(
+  IN UINTN TotalModules
+  )
+{
+  UINTN Characters = TotalModules * 2;
+  CHAR16 RowBuffer[(COMPUTER_INFO_QR_SIZE + (QUIET_ZONE_SIZE * 2)) * 2 + 1];
+
+  for (UINTN Index = 0; Index < Characters; Index++) {
+    RowBuffer[Index] = L' ';
+  }
+  RowBuffer[Characters] = L'\0';
+  Print(L"%s\n", RowBuffer);
+}
+
+STATIC
+VOID
+RenderQrRow(
+  IN CONST COMPUTER_INFO_QR_CODE *QrCode,
+  IN UINTN                        RowIndex
+  )
+{
+  CHAR16 RowBuffer[(COMPUTER_INFO_QR_SIZE + (QUIET_ZONE_SIZE * 2)) * 2 + 1];
+  UINTN Position = 0;
+
+  for (UINTN Index = 0; Index < QUIET_ZONE_SIZE; Index++) {
+    RowBuffer[Position++] = L' ';
+    RowBuffer[Position++] = L' ';
+  }
+
+  for (UINTN Column = 0; Column < QrCode->Size; Column++) {
+    if (QrCode->Modules[RowIndex][Column] != 0) {
+      RowBuffer[Position++] = L'\u2588';
+      RowBuffer[Position++] = L'\u2588';
+    } else {
+      RowBuffer[Position++] = L' ';
+      RowBuffer[Position++] = L' ';
+    }
+  }
+
+  for (UINTN Index = 0; Index < QUIET_ZONE_SIZE; Index++) {
+    RowBuffer[Position++] = L' ';
+    RowBuffer[Position++] = L' ';
+  }
+
+  RowBuffer[Position] = L'\0';
+  Print(L"%s\n", RowBuffer);
+}
+
+STATIC
+VOID
+RenderQrCode(
+  IN CONST COMPUTER_INFO_QR_CODE *QrCode
+  )
+{
+  UINTN DisplayWidth = QrCode->Size + (QUIET_ZONE_SIZE * 2);
+
+  for (UINTN Index = 0; Index < QUIET_ZONE_SIZE; Index++) {
+    RenderQuietRow(DisplayWidth);
+  }
+
+  for (UINTN Row = 0; Row < QrCode->Size; Row++) {
+    RenderQrRow(QrCode, Row);
+  }
+
+  for (UINTN Index = 0; Index < QUIET_ZONE_SIZE; Index++) {
+    RenderQuietRow(DisplayWidth);
+  }
+}
+
+EFI_STATUS
+EFIAPI
+UefiMain(
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE *SystemTable
+  )
+{
+  EFI_STATUS Status;
+  CHAR8     Vendor[VENDOR_MAX_LENGTH + 1];
+  CHAR8     InfoBuffer[INFO_BUFFER_LENGTH];
+  UINT64    TotalMemoryMb;
+  UINTN     DescriptorCount;
+
+  SetMem(Vendor, sizeof(Vendor), 0);
+  PrepareVendorString(Vendor, sizeof(Vendor), gST->FirmwareVendor);
+
+  Status = GetMemoryStatistics(&TotalMemoryMb, &DescriptorCount);
+  if (EFI_ERROR(Status)) {
+    Print(L"Failed to retrieve memory information: %r\n", Status);
+    return Status;
+  }
+
+  if (TotalMemoryMb > 99999) {
+    TotalMemoryMb = 99999;
+  }
+
+  if (DescriptorCount > 999) {
+    DescriptorCount = 999;
+  }
+
+  AsciiSPrint(
+    InfoBuffer,
+    sizeof(InfoBuffer),
+    "V:%a|R:%08X|M:%05Lu|D:%03u",
+    Vendor,
+    gST->FirmwareRevision,
+    TotalMemoryMb,
+    (UINT32)DescriptorCount
+    );
+
+  InfoBuffer[COMPUTER_INFO_QR_MAX_DATA_LENGTH] = '\0';
+  UINTN DataLength = AsciiStrLen(InfoBuffer);
+  if (DataLength > COMPUTER_INFO_QR_MAX_DATA_LENGTH) {
+    DataLength = COMPUTER_INFO_QR_MAX_DATA_LENGTH;
+  }
+
+  COMPUTER_INFO_QR_CODE QrCode;
+  Status = GenerateComputerInfoQrCode((CONST UINT8 *)InfoBuffer, DataLength, &QrCode);
+  if (EFI_ERROR(Status)) {
+    Print(L"QR code generation failed: %r\n", Status);
+    return Status;
+  }
+
+  if (gST->ConOut != NULL) {
+    gST->ConOut->ClearScreen(gST->ConOut);
+  }
+
+  Print(L"Computer information encoded as QR code:\n\n");
+  RenderQrCode(&QrCode);
+  Print(L"\nRaw data: %a\n", InfoBuffer);
+
+  return EFI_SUCCESS;
+}

--- a/ComputerInfoQrPkg/Application/ComputerInfoQrApp.inf
+++ b/ComputerInfoQrPkg/Application/ComputerInfoQrApp.inf
@@ -1,0 +1,23 @@
+[Defines]
+  INF_VERSION                    = 0x00010017
+  BASE_NAME                      = ComputerInfoQrApp
+  FILE_GUID                      = 14d5b6f9-4539-40a8-9b41-cd19f732a59f
+  MODULE_TYPE                    = UEFI_APPLICATION
+  VERSION_STRING                 = 0.1
+  ENTRY_POINT                    = UefiMain
+
+[Sources]
+  ComputerInfoQrApp.c
+  QrCode.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  ComputerInfoQrPkg/ComputerInfoQrPkg.dec
+
+[LibraryClasses]
+  UefiApplicationEntryPoint
+  UefiLib
+  PrintLib
+  BaseLib
+  BaseMemoryLib
+  MemoryAllocationLib

--- a/ComputerInfoQrPkg/Application/QrCode.c
+++ b/ComputerInfoQrPkg/Application/QrCode.c
@@ -1,0 +1,704 @@
+#include "QrCode.h"
+
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+
+#define QR_VERSION                    COMPUTER_INFO_QR_VERSION
+#define QR_SIZE_PIXELS                COMPUTER_INFO_QR_SIZE
+#define QR_DATA_CODEWORDS             34
+#define QR_ECC_CODEWORDS              10
+#define QR_TOTAL_CODEWORDS            44
+#define QR_REMAINDER_BITS             7
+#define QR_DATA_BIT_CAPACITY          (QR_DATA_CODEWORDS * 8)
+
+#define GF_SIZE                       256
+#define GF_GENERATOR_POLYNOMIAL       0x11D
+
+typedef struct {
+  UINT8 Bytes[QR_DATA_CODEWORDS];
+  UINTN BitLength;
+} QR_BIT_BUFFER;
+
+STATIC UINT8   mGaloisExpTable[GF_SIZE * 2];
+STATIC UINT8   mGaloisLogTable[GF_SIZE];
+STATIC BOOLEAN mGaloisTablesReady = FALSE;
+
+STATIC
+VOID
+InitializeGaloisTables(
+  VOID
+  )
+{
+  if (mGaloisTablesReady) {
+    return;
+  }
+
+  UINT16 Value = 1;
+  for (UINTN Index = 0; Index < GF_SIZE - 1; Index++) {
+    mGaloisExpTable[Index] = (UINT8)Value;
+    mGaloisLogTable[Value] = (UINT8)Index;
+    Value <<= 1;
+    if (Value & GF_SIZE) {
+      Value ^= GF_GENERATOR_POLYNOMIAL;
+    }
+  }
+
+  for (UINTN Index = GF_SIZE - 1; Index < GF_SIZE * 2; Index++) {
+    mGaloisExpTable[Index] = mGaloisExpTable[Index - (GF_SIZE - 1)];
+  }
+
+  mGaloisTablesReady = TRUE;
+}
+
+STATIC
+UINT8
+GaloisMultiply(
+  IN UINT8 A,
+  IN UINT8 B
+  )
+{
+  if (A == 0 || B == 0) {
+    return 0;
+  }
+
+  UINTN LogSum = mGaloisLogTable[A] + mGaloisLogTable[B];
+  return mGaloisExpTable[LogSum % (GF_SIZE - 1)];
+}
+
+STATIC
+UINT8
+GaloisPowerOfTwo(
+  IN UINTN Exponent
+  )
+{
+  return mGaloisExpTable[Exponent % (GF_SIZE - 1)];
+}
+
+STATIC
+VOID
+BitBufferInit(
+  OUT QR_BIT_BUFFER *Buffer
+  )
+{
+  ZeroMem(Buffer->Bytes, sizeof(Buffer->Bytes));
+  Buffer->BitLength = 0;
+}
+
+STATIC
+EFI_STATUS
+BitBufferAppendBits(
+  IN OUT QR_BIT_BUFFER *Buffer,
+  IN UINT32             Value,
+  IN UINTN              Count
+  )
+{
+  if (Count == 0) {
+    return EFI_SUCCESS;
+  }
+
+  if (Count > 24) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (INTN Bit = (INTN)Count - 1; Bit >= 0; Bit--) {
+    UINTN ByteIndex = Buffer->BitLength / 8;
+    if (ByteIndex >= QR_DATA_CODEWORDS) {
+      return EFI_BUFFER_TOO_SMALL;
+    }
+
+    UINTN BitOffset = 7 - (Buffer->BitLength % 8);
+    UINT8 Mask = (UINT8)((Value >> Bit) & 0x1);
+    Buffer->Bytes[ByteIndex] |= (UINT8)(Mask << BitOffset);
+    Buffer->BitLength++;
+  }
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+BuildDataCodewords(
+  IN  CONST UINT8 *Payload,
+  IN  UINTN        PayloadLength,
+  OUT UINT8       *Codewords
+  )
+{
+  if (PayloadLength > COMPUTER_INFO_QR_MAX_DATA_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  QR_BIT_BUFFER Buffer;
+  BitBufferInit(&Buffer);
+
+  EFI_STATUS Status;
+
+  Status = BitBufferAppendBits(&Buffer, 0x4, 4);
+  if (EFI_ERROR(Status)) {
+    return Status;
+  }
+
+  Status = BitBufferAppendBits(&Buffer, (UINT32)PayloadLength, 8);
+  if (EFI_ERROR(Status)) {
+    return Status;
+  }
+
+  for (UINTN Index = 0; Index < PayloadLength; Index++) {
+    Status = BitBufferAppendBits(&Buffer, Payload[Index], 8);
+    if (EFI_ERROR(Status)) {
+      return Status;
+    }
+  }
+
+  if (Buffer.BitLength > QR_DATA_BIT_CAPACITY) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  UINTN RemainingBits = QR_DATA_BIT_CAPACITY - Buffer.BitLength;
+  UINTN TerminatorBits = (RemainingBits < 4) ? RemainingBits : 4;
+
+  Status = BitBufferAppendBits(&Buffer, 0, TerminatorBits);
+  if (EFI_ERROR(Status)) {
+    return Status;
+  }
+
+  if ((Buffer.BitLength % 8) != 0) {
+    Status = BitBufferAppendBits(&Buffer, 0, 8 - (Buffer.BitLength % 8));
+    if (EFI_ERROR(Status)) {
+      return Status;
+    }
+  }
+
+  BOOLEAN Toggle = TRUE;
+  while (Buffer.BitLength < QR_DATA_BIT_CAPACITY) {
+    UINT8 Pad = Toggle ? 0xEC : 0x11;
+    Status = BitBufferAppendBits(&Buffer, Pad, 8);
+    if (EFI_ERROR(Status)) {
+      return Status;
+    }
+    Toggle = !Toggle;
+  }
+
+  CopyMem(Codewords, Buffer.Bytes, QR_DATA_CODEWORDS);
+  return EFI_SUCCESS;
+}
+
+STATIC
+VOID
+ComputeGeneratorPolynomial(
+  IN  UINTN Degree,
+  OUT UINT8 *Result
+  )
+{
+  SetMem(Result, (Degree + 1) * sizeof(UINT8), 0);
+  Result[0] = 1;
+
+  for (UINTN D = 0; D < Degree; D++) {
+    UINT8 Factor = GaloisPowerOfTwo(D);
+    Result[D + 1] = 0;
+    for (INTN Index = (INTN)D + 1; Index > 0; Index--) {
+      UINT8 Current = Result[Index];
+      UINT8 Product = GaloisMultiply(Result[Index - 1], Factor);
+      Result[Index] = Current ^ Product;
+    }
+  }
+}
+
+STATIC
+VOID
+ComputeReedSolomon(
+  IN  CONST UINT8 *Data,
+  IN  UINTN        DataCount,
+  OUT UINT8       *Parity,
+  IN  UINTN        ParityCount
+  )
+{
+  SetMem(Parity, ParityCount * sizeof(UINT8), 0);
+
+  UINT8 Generator[QR_ECC_CODEWORDS + 1];
+  ComputeGeneratorPolynomial(ParityCount, Generator);
+
+  for (UINTN Index = 0; Index < DataCount; Index++) {
+    UINT8 Factor = Data[Index] ^ Parity[0];
+
+    for (UINTN Shift = 0; Shift < ParityCount - 1; Shift++) {
+      Parity[Shift] = Parity[Shift + 1];
+    }
+    Parity[ParityCount - 1] = 0;
+
+    for (UINTN GenIndex = 0; GenIndex < ParityCount; GenIndex++) {
+      UINT8 GeneratorCoeff = Generator[GenIndex + 1];
+      UINT8 Product = GaloisMultiply(GeneratorCoeff, Factor);
+      Parity[GenIndex] ^= Product;
+    }
+  }
+}
+
+STATIC
+VOID
+DrawFinderPattern(
+  IN OUT INT8    Modules[QR_SIZE_PIXELS][QR_SIZE_PIXELS],
+  IN OUT BOOLEAN FunctionModules[QR_SIZE_PIXELS][QR_SIZE_PIXELS],
+  IN     INTN    X,
+  IN     INTN    Y
+  )
+{
+  for (INTN Dy = 0; Dy < 7; Dy++) {
+    for (INTN Dx = 0; Dx < 7; Dx++) {
+      INTN PosX = X + Dx;
+      INTN PosY = Y + Dy;
+      if (PosX < 0 || PosY < 0 || PosX >= QR_SIZE_PIXELS || PosY >= QR_SIZE_PIXELS) {
+        continue;
+      }
+
+      BOOLEAN Outer = (Dx == 0 || Dx == 6 || Dy == 0 || Dy == 6);
+      BOOLEAN Inner = (Dx >= 2 && Dx <= 4 && Dy >= 2 && Dy <= 4);
+      UINT8 Value = (Outer || Inner) ? 1 : 0;
+      Modules[PosY][PosX] = (INT8)Value;
+      FunctionModules[PosY][PosX] = TRUE;
+    }
+  }
+
+  for (INTN Dy = -1; Dy <= 7; Dy++) {
+    for (INTN Dx = -1; Dx <= 7; Dx++) {
+      INTN PosX = X + Dx;
+      INTN PosY = Y + Dy;
+      if (PosX < 0 || PosY < 0 || PosX >= QR_SIZE_PIXELS || PosY >= QR_SIZE_PIXELS) {
+        continue;
+      }
+
+      if (PosX >= X && PosX < X + 7 && PosY >= Y && PosY < Y + 7) {
+        continue;
+      }
+
+      Modules[PosY][PosX] = 0;
+      FunctionModules[PosY][PosX] = TRUE;
+    }
+  }
+}
+
+STATIC
+VOID
+DrawAlignmentPattern(
+  IN OUT INT8    Modules[QR_SIZE_PIXELS][QR_SIZE_PIXELS],
+  IN OUT BOOLEAN FunctionModules[QR_SIZE_PIXELS][QR_SIZE_PIXELS],
+  IN     INTN    CenterX,
+  IN     INTN    CenterY
+  )
+{
+  for (INTN Dy = -2; Dy <= 2; Dy++) {
+    for (INTN Dx = -2; Dx <= 2; Dx++) {
+      INTN PosX = CenterX + Dx;
+      INTN PosY = CenterY + Dy;
+      if (PosX < 0 || PosY < 0 || PosX >= QR_SIZE_PIXELS || PosY >= QR_SIZE_PIXELS) {
+        continue;
+      }
+
+      INTN AbsDx = (Dx >= 0) ? Dx : -Dx;
+      INTN AbsDy = (Dy >= 0) ? Dy : -Dy;
+      INTN Distance = (AbsDx > AbsDy) ? AbsDx : AbsDy;
+      UINT8 Value = (UINT8)((Distance != 1) ? 1 : 0);
+      Modules[PosY][PosX] = (INT8)Value;
+      FunctionModules[PosY][PosX] = TRUE;
+    }
+  }
+}
+
+STATIC
+VOID
+DrawTimingPatterns(
+  IN OUT INT8    Modules[QR_SIZE_PIXELS][QR_SIZE_PIXELS],
+  IN OUT BOOLEAN FunctionModules[QR_SIZE_PIXELS][QR_SIZE_PIXELS]
+  )
+{
+  for (INTN Index = 0; Index < QR_SIZE_PIXELS; Index++) {
+    if (!FunctionModules[6][Index]) {
+      Modules[6][Index] = (INT8)((Index % 2) == 0);
+      FunctionModules[6][Index] = TRUE;
+    }
+    if (!FunctionModules[Index][6]) {
+      Modules[Index][6] = (INT8)((Index % 2) == 0);
+      FunctionModules[Index][6] = TRUE;
+    }
+  }
+}
+
+STATIC
+VOID
+ReserveFormatInfo(
+  IN OUT BOOLEAN FunctionModules[QR_SIZE_PIXELS][QR_SIZE_PIXELS]
+  )
+{
+  for (INTN Index = 0; Index <= 8; Index++) {
+    if (Index != 6) {
+      FunctionModules[8][Index] = TRUE;
+      FunctionModules[Index][8] = TRUE;
+    }
+  }
+
+  for (INTN Index = 0; Index < 7; Index++) {
+    FunctionModules[8][QR_SIZE_PIXELS - 1 - Index] = TRUE;
+    FunctionModules[QR_SIZE_PIXELS - 1 - Index][8] = TRUE;
+  }
+
+  FunctionModules[8][QR_SIZE_PIXELS - 8] = TRUE;
+  FunctionModules[QR_SIZE_PIXELS - 8][8] = TRUE;
+}
+
+STATIC
+BOOLEAN
+IsFunctionModule(
+  IN BOOLEAN FunctionModules[QR_SIZE_PIXELS][QR_SIZE_PIXELS],
+  IN INTN    X,
+  IN INTN    Y
+  )
+{
+  if (X < 0 || Y < 0 || X >= QR_SIZE_PIXELS || Y >= QR_SIZE_PIXELS) {
+    return TRUE;
+  }
+  return FunctionModules[Y][X];
+}
+
+STATIC
+VOID
+PlaceDataBits(
+  IN OUT INT8    Modules[QR_SIZE_PIXELS][QR_SIZE_PIXELS],
+  IN     BOOLEAN FunctionModules[QR_SIZE_PIXELS][QR_SIZE_PIXELS],
+  IN     CONST UINT8 *Bits,
+  IN     UINTN        BitCount
+  )
+{
+  UINTN BitIndex = 0;
+  BOOLEAN GoingUp = TRUE;
+
+  for (INTN Column = QR_SIZE_PIXELS - 1; Column > 0; Column -= 2) {
+    if (Column == 6) {
+      Column--;
+    }
+
+    for (INTN Offset = 0; Offset < QR_SIZE_PIXELS; Offset++) {
+      INTN Row = GoingUp ? (QR_SIZE_PIXELS - 1 - Offset) : Offset;
+
+      for (INTN ColumnOffset = 0; ColumnOffset < 2; ColumnOffset++) {
+        INTN CurrentColumn = Column - ColumnOffset;
+        if (IsFunctionModule(FunctionModules, CurrentColumn, Row)) {
+          continue;
+        }
+
+        UINT8 BitValue = 0;
+        if (BitIndex < BitCount) {
+          BitValue = Bits[BitIndex];
+        }
+        Modules[Row][CurrentColumn] = (INT8)BitValue;
+        BitIndex++;
+      }
+    }
+
+    GoingUp = !GoingUp;
+  }
+}
+
+STATIC
+UINT8
+MaskBit(
+  IN UINTN Mask,
+  IN INTN  X,
+  IN INTN  Y
+  )
+{
+  switch (Mask) {
+  case 0:
+    return (UINT8)(((X + Y) & 0x1) == 0);
+  case 1:
+    return (UINT8)((Y & 0x1) == 0);
+  case 2:
+    return (UINT8)((X % 3) == 0);
+  case 3:
+    return (UINT8)(((X + Y) % 3) == 0);
+  case 4:
+    return (UINT8)((((Y / 2) + (X / 3)) & 0x1) == 0);
+  case 5:
+    return (UINT8)((((X * Y) % 2) + ((X * Y) % 3)) == 0);
+  case 6:
+    return (UINT8)(((((X * Y) % 2) + ((X * Y) % 3)) & 0x1) == 0);
+  case 7:
+    return (UINT8)(((((X + Y) % 2) + ((X * Y) % 3)) & 0x1) == 0);
+  default:
+    return 0;
+  }
+}
+
+STATIC
+VOID
+ApplyMask(
+  IN OUT INT8    Modules[QR_SIZE_PIXELS][QR_SIZE_PIXELS],
+  IN     BOOLEAN FunctionModules[QR_SIZE_PIXELS][QR_SIZE_PIXELS],
+  IN     UINTN   Mask
+  )
+{
+  for (INTN Y = 0; Y < QR_SIZE_PIXELS; Y++) {
+    for (INTN X = 0; X < QR_SIZE_PIXELS; X++) {
+      if (FunctionModules[Y][X]) {
+        continue;
+      }
+      if (MaskBit(Mask, X, Y)) {
+        Modules[Y][X] ^= 1;
+      }
+    }
+  }
+}
+
+STATIC
+UINT16
+CalculateFormatBits(
+  IN UINTN Mask
+  )
+{
+  UINT16 Format = 0;
+  UINT16 Data = (UINT16)((0x01 << 3) | (Mask & 0x7));
+  Format = (UINT16)(Data << 10);
+
+  UINT16 Polynomial = 0x537;
+  for (INTN Bit = 14; Bit >= 10; Bit--) {
+    if ((Format >> Bit) & 0x1) {
+      Format ^= (UINT16)(Polynomial << (Bit - 10));
+    }
+  }
+
+  Format = (UINT16)((Data << 10) | Format);
+  Format ^= 0x5412;
+  return Format;
+}
+
+STATIC
+VOID
+DrawFormatBits(
+  IN OUT INT8    Modules[QR_SIZE_PIXELS][QR_SIZE_PIXELS],
+  IN OUT BOOLEAN FunctionModules[QR_SIZE_PIXELS][QR_SIZE_PIXELS],
+  IN     UINTN   Mask
+  )
+{
+  UINT16 Format = CalculateFormatBits(Mask);
+
+  for (INTN Index = 0; Index <= 5; Index++) {
+    UINT8 Bit = (UINT8)((Format >> Index) & 0x1);
+    Modules[8][Index] = (INT8)Bit;
+    FunctionModules[8][Index] = TRUE;
+  }
+
+  Modules[8][7] = (INT8)((Format >> 6) & 0x1);
+  FunctionModules[8][7] = TRUE;
+  Modules[8][8] = (INT8)((Format >> 7) & 0x1);
+  FunctionModules[8][8] = TRUE;
+  Modules[7][8] = (INT8)((Format >> 8) & 0x1);
+  FunctionModules[7][8] = TRUE;
+
+  for (INTN Index = 9; Index < 15; Index++) {
+    UINT8 Bit = (UINT8)((Format >> Index) & 0x1);
+    Modules[14 - Index][8] = (INT8)Bit;
+    FunctionModules[14 - Index][8] = TRUE;
+  }
+
+  for (INTN Index = 0; Index < 8; Index++) {
+    UINT8 Bit = (UINT8)((Format >> Index) & 0x1);
+    Modules[QR_SIZE_PIXELS - 1 - Index][8] = (INT8)Bit;
+    FunctionModules[QR_SIZE_PIXELS - 1 - Index][8] = TRUE;
+  }
+
+  for (INTN Index = 8; Index < 15; Index++) {
+    UINT8 Bit = (UINT8)((Format >> Index) & 0x1);
+    Modules[8][QR_SIZE_PIXELS - 15 + Index] = (INT8)Bit;
+    FunctionModules[8][QR_SIZE_PIXELS - 15 + Index] = TRUE;
+  }
+
+  Modules[8][QR_SIZE_PIXELS - 8] = 1;
+  FunctionModules[8][QR_SIZE_PIXELS - 8] = TRUE;
+}
+
+STATIC
+INT32
+ScoreRunPenalty(
+  IN INT8 Line[QR_SIZE_PIXELS]
+  )
+{
+  INT32 Penalty = 0;
+  INTN RunLength = 1;
+
+  for (INTN Index = 1; Index < QR_SIZE_PIXELS; Index++) {
+    if (Line[Index] == Line[Index - 1]) {
+      RunLength++;
+    } else {
+      if (RunLength >= 5) {
+        Penalty += 3 + (RunLength - 5);
+      }
+      RunLength = 1;
+    }
+  }
+
+  if (RunLength >= 5) {
+    Penalty += 3 + (RunLength - 5);
+  }
+
+  return Penalty;
+}
+
+STATIC
+INT32
+EvaluatePenalty(
+  IN INT8 Modules[QR_SIZE_PIXELS][QR_SIZE_PIXELS]
+  )
+{
+  INT32 Penalty = 0;
+
+  for (INTN Y = 0; Y < QR_SIZE_PIXELS; Y++) {
+    Penalty += ScoreRunPenalty(Modules[Y]);
+  }
+
+  for (INTN X = 0; X < QR_SIZE_PIXELS; X++) {
+    INT8 Column[QR_SIZE_PIXELS];
+    for (INTN Y = 0; Y < QR_SIZE_PIXELS; Y++) {
+      Column[Y] = Modules[Y][X];
+    }
+    Penalty += ScoreRunPenalty(Column);
+  }
+
+  for (INTN Y = 0; Y < QR_SIZE_PIXELS - 1; Y++) {
+    for (INTN X = 0; X < QR_SIZE_PIXELS - 1; X++) {
+      INT8 Value = Modules[Y][X];
+      if (Value == Modules[Y][X + 1] &&
+          Value == Modules[Y + 1][X] &&
+          Value == Modules[Y + 1][X + 1]) {
+        Penalty += 3;
+      }
+    }
+  }
+
+  for (INTN Y = 0; Y < QR_SIZE_PIXELS; Y++) {
+    for (INTN X = 0; X <= QR_SIZE_PIXELS - 11; X++) {
+      if (Modules[Y][X] && !Modules[Y][X + 1] && Modules[Y][X + 2] && Modules[Y][X + 3] && Modules[Y][X + 4] && !Modules[Y][X + 5] && Modules[Y][X + 6] &&
+          !Modules[Y][X + 7] && !Modules[Y][X + 8] && !Modules[Y][X + 9] && !Modules[Y][X + 10]) {
+        Penalty += 40;
+      }
+      if (!Modules[Y][X] && Modules[Y][X + 1] && !Modules[Y][X + 2] && !Modules[Y][X + 3] && !Modules[Y][X + 4] && Modules[Y][X + 5] && !Modules[Y][X + 6] &&
+          Modules[Y][X + 7] && Modules[Y][X + 8] && Modules[Y][X + 9] && Modules[Y][X + 10]) {
+        Penalty += 40;
+      }
+    }
+  }
+
+  for (INTN X = 0; X < QR_SIZE_PIXELS; X++) {
+    for (INTN Y = 0; Y <= QR_SIZE_PIXELS - 11; Y++) {
+      if (Modules[Y][X] && !Modules[Y + 1][X] && Modules[Y + 2][X] && Modules[Y + 3][X] && Modules[Y + 4][X] && !Modules[Y + 5][X] && Modules[Y + 6][X] &&
+          !Modules[Y + 7][X] && !Modules[Y + 8][X] && !Modules[Y + 9][X] && !Modules[Y + 10][X]) {
+        Penalty += 40;
+      }
+      if (!Modules[Y][X] && Modules[Y + 1][X] && !Modules[Y + 2][X] && !Modules[Y + 3][X] && !Modules[Y + 4][X] && Modules[Y + 5][X] && !Modules[Y + 6][X] &&
+          Modules[Y + 7][X] && Modules[Y + 8][X] && Modules[Y + 9][X] && Modules[Y + 10][X]) {
+        Penalty += 40;
+      }
+    }
+  }
+
+  UINTN DarkCount = 0;
+  for (INTN Y = 0; Y < QR_SIZE_PIXELS; Y++) {
+    for (INTN X = 0; X < QR_SIZE_PIXELS; X++) {
+      if (Modules[Y][X]) {
+        DarkCount++;
+      }
+    }
+  }
+
+  UINTN TotalModules = QR_SIZE_PIXELS * QR_SIZE_PIXELS;
+  INTN Percent = (INTN)((DarkCount * 100 + TotalModules / 2) / TotalModules);
+  INTN FivePercent = ABS(Percent - 50) / 5;
+  Penalty += FivePercent * 10;
+
+  return Penalty;
+}
+
+EFI_STATUS
+GenerateComputerInfoQrCode(
+  IN  CONST UINT8           *Payload,
+  IN  UINTN                 PayloadLength,
+  OUT COMPUTER_INFO_QR_CODE *QrCode
+  )
+{
+  if (Payload == NULL || QrCode == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (PayloadLength == 0 || PayloadLength > COMPUTER_INFO_QR_MAX_DATA_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  InitializeGaloisTables();
+
+  UINT8 DataCodewords[QR_DATA_CODEWORDS];
+  EFI_STATUS Status = BuildDataCodewords(Payload, PayloadLength, DataCodewords);
+  if (EFI_ERROR(Status)) {
+    return Status;
+  }
+
+  UINT8 EccCodewords[QR_ECC_CODEWORDS];
+  ComputeReedSolomon(DataCodewords, QR_DATA_CODEWORDS, EccCodewords, QR_ECC_CODEWORDS);
+
+  UINT8 Codewords[QR_TOTAL_CODEWORDS];
+  CopyMem(Codewords, DataCodewords, QR_DATA_CODEWORDS);
+  CopyMem(Codewords + QR_DATA_CODEWORDS, EccCodewords, QR_ECC_CODEWORDS);
+
+  UINTN TotalDataBits = QR_TOTAL_CODEWORDS * 8 + QR_REMAINDER_BITS;
+  UINT8 DataBits[QR_TOTAL_CODEWORDS * 8 + QR_REMAINDER_BITS];
+  for (UINTN Bit = 0; Bit < QR_TOTAL_CODEWORDS * 8; Bit++) {
+    UINT8 Byte = Codewords[Bit / 8];
+    DataBits[Bit] = (UINT8)((Byte >> (7 - (Bit % 8))) & 0x1);
+  }
+  for (UINTN Bit = QR_TOTAL_CODEWORDS * 8; Bit < TotalDataBits; Bit++) {
+    DataBits[Bit] = 0;
+  }
+
+  INT8 BaseModules[QR_SIZE_PIXELS][QR_SIZE_PIXELS];
+  BOOLEAN FunctionModules[QR_SIZE_PIXELS][QR_SIZE_PIXELS];
+  for (INTN Y = 0; Y < QR_SIZE_PIXELS; Y++) {
+    for (INTN X = 0; X < QR_SIZE_PIXELS; X++) {
+      BaseModules[Y][X] = 0;
+      FunctionModules[Y][X] = FALSE;
+    }
+  }
+
+  DrawFinderPattern(BaseModules, FunctionModules, 0, 0);
+  DrawFinderPattern(BaseModules, FunctionModules, QR_SIZE_PIXELS - 7, 0);
+  DrawFinderPattern(BaseModules, FunctionModules, 0, QR_SIZE_PIXELS - 7);
+
+  DrawTimingPatterns(BaseModules, FunctionModules);
+
+  DrawAlignmentPattern(BaseModules, FunctionModules, QR_SIZE_PIXELS - 7, QR_SIZE_PIXELS - 7);
+
+  ReserveFormatInfo(FunctionModules);
+
+  BaseModules[QR_SIZE_PIXELS - 8][8] = 1;
+  FunctionModules[QR_SIZE_PIXELS - 8][8] = TRUE;
+
+  PlaceDataBits(BaseModules, FunctionModules, DataBits, TotalDataBits);
+
+  INT32 BestPenalty = MAX_INT32;
+  INT8 BestModules[QR_SIZE_PIXELS][QR_SIZE_PIXELS];
+
+  for (UINTN Mask = 0; Mask < 8; Mask++) {
+    INT8 MaskedModules[QR_SIZE_PIXELS][QR_SIZE_PIXELS];
+    BOOLEAN MaskedFunction[QR_SIZE_PIXELS][QR_SIZE_PIXELS];
+    CopyMem(MaskedModules, BaseModules, sizeof(BaseModules));
+    CopyMem(MaskedFunction, FunctionModules, sizeof(FunctionModules));
+
+    ApplyMask(MaskedModules, MaskedFunction, Mask);
+    DrawFormatBits(MaskedModules, MaskedFunction, Mask);
+
+    INT32 Penalty = EvaluatePenalty(MaskedModules);
+    if (Penalty < BestPenalty) {
+      BestPenalty = Penalty;
+      CopyMem(BestModules, MaskedModules, sizeof(BestModules));
+    }
+  }
+
+  CopyMem(QrCode->Modules, BestModules, sizeof(BestModules));
+  QrCode->Size = QR_SIZE_PIXELS;
+  return EFI_SUCCESS;
+}

--- a/ComputerInfoQrPkg/Application/QrCode.h
+++ b/ComputerInfoQrPkg/Application/QrCode.h
@@ -1,0 +1,22 @@
+#ifndef COMPUTER_INFO_QR_QRCODE_H_
+#define COMPUTER_INFO_QR_QRCODE_H_
+
+#include <Uefi.h>
+
+#define COMPUTER_INFO_QR_VERSION             2
+#define COMPUTER_INFO_QR_SIZE                (4 * COMPUTER_INFO_QR_VERSION + 17)
+#define COMPUTER_INFO_QR_MAX_DATA_LENGTH     32
+
+typedef struct {
+  UINTN Size;
+  UINT8 Modules[COMPUTER_INFO_QR_SIZE][COMPUTER_INFO_QR_SIZE];
+} COMPUTER_INFO_QR_CODE;
+
+EFI_STATUS
+GenerateComputerInfoQrCode(
+  IN  CONST UINT8              *Payload,
+  IN  UINTN                    PayloadLength,
+  OUT COMPUTER_INFO_QR_CODE    *QrCode
+  );
+
+#endif

--- a/ComputerInfoQrPkg/ComputerInfoQrPkg.dec
+++ b/ComputerInfoQrPkg/ComputerInfoQrPkg.dec
@@ -1,0 +1,8 @@
+[Defines]
+  DEC_SPECIFICATION = 0x00010005
+  PACKAGE_NAME      = ComputerInfoQrPkg
+  PACKAGE_GUID      = 06b2ac78-52a0-4d7a-b513-b41726b0d830
+  PACKAGE_VERSION   = 0.1
+
+[Includes]
+  Include

--- a/ComputerInfoQrPkg/ComputerInfoQrPkg.dsc
+++ b/ComputerInfoQrPkg/ComputerInfoQrPkg.dsc
@@ -1,0 +1,20 @@
+[Defines]
+  PLATFORM_NAME           = ComputerInfoQrPkg
+  PLATFORM_GUID           = 9e497b77-3f2f-4d6f-bf34-a39ef79ff4da
+  PLATFORM_VERSION        = 0.1
+  DSC_SPECIFICATION       = 0x00010005
+  OUTPUT_DIRECTORY        = Build/ComputerInfoQr
+  SUPPORTED_ARCHITECTURES = IA32 X64 AARCH64
+  BUILD_TARGETS           = DEBUG RELEASE
+  SKUID_IDENTIFIER        = DEFAULT
+
+[LibraryClasses]
+  UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
+  UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
+  PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
+  BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
+  BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+  MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+
+[Components]
+  ComputerInfoQrPkg/Application/ComputerInfoQrApp.inf

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # UEFI-Playground
+
+This repository contains a standalone EDK II package named `ComputerInfoQrPkg`.
+The package builds a UEFI application that collects key firmware and memory
+statistics from the running machine and renders them as a QR code directly in
+the UEFI console. The QR code generator is implemented from scratch and does
+not rely on any external libraries.
+
+## Package layout
+
+```
+ComputerInfoQrPkg/
+├── Application/
+│   ├── ComputerInfoQrApp.c      # UEFI entry point and rendering helpers
+│   ├── ComputerInfoQrApp.inf    # Module description
+│   ├── QrCode.c                 # QR code encoder implementation
+│   └── QrCode.h                 # Shared QR definitions
+├── ComputerInfoQrPkg.dec        # Package declaration
+└── ComputerInfoQrPkg.dsc        # Platform description for building
+```
+
+## Building the application
+
+1. Set up an [EDK II](https://github.com/tianocore/edk2) workspace and install
+   the toolchain for your target architecture.
+2. Copy or clone this repository inside the workspace root so that
+   `ComputerInfoQrPkg` sits alongside the other packages.
+3. Initialize the EDK II build environment (for example, on Linux:
+   `source edksetup.sh`).
+4. Build the application by invoking:
+
+   ```bash
+   build -p ComputerInfoQrPkg/ComputerInfoQrPkg.dsc -m ComputerInfoQrPkg/Application/ComputerInfoQrApp.inf -a X64 -t GCC5
+   ```
+
+   Adjust `-a` and `-t` to match your desired architecture and toolchain.
+
+The resulting EFI binary will be placed in the `Build/ComputerInfoQr/` output
+folder created by EDK II. Copy the application to your preferred boot medium
+(e.g. a USB drive) and launch it from a UEFI shell to view the QR code.
+
+## Displayed information
+
+The QR payload encodes a concise string containing:
+
+- A truncated firmware vendor identifier.
+- The firmware revision.
+- The total amount of system memory (in MiB, capped to five digits).
+- The number of descriptors reported in the firmware memory map (capped to
+  three digits).
+
+An ASCII rendering of the QR code is shown on screen together with the raw data
+string, making it simple to scan the code with another device.


### PR DESCRIPTION
## Summary
- add the ComputerInfoQrPkg EDK II package with a QR encoder implementation and entry-point application
- collect firmware vendor, revision, memory size, and descriptor statistics to build a concise payload
- render the payload as an ASCII QR code on the UEFI console and document build instructions in the README

## Testing
- not run (EDK II toolchain not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68c87816f40c8321809e6f9e3baa3fb3