### PR TITLE
Encode system identifiers in QR-only output

### DIFF
--- a/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
+++ b/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
@@ -1,5 +1,6 @@
 #include <Uefi.h>
 
+#include <IndustryStandard/SmBios.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
@@ -7,92 +8,335 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
 
+#include <Protocol/SimpleNetwork.h>
 #include <Protocol/SimpleTextIn.h>
+#include <Protocol/Smbios.h>
 
 #include "QrCode.h"
 
-#define QUIET_ZONE_SIZE             2
-#define VENDOR_MAX_LENGTH           5
-#define INFO_BUFFER_LENGTH          64
+#define QUIET_ZONE_SIZE                 2
+#define INFO_BUFFER_LENGTH              (COMPUTER_INFO_QR_MAX_DATA_LENGTH + 1)
+#define UUID_STRING_LENGTH              36
+#define UUID_STRING_BUFFER_LENGTH       (UUID_STRING_LENGTH + 1)
+#define MAC_ADDRESS_MAX_BYTES           32
+#define MAC_STRING_MAX_LENGTH           (MAC_ADDRESS_MAX_BYTES * 2)
+#define MAC_STRING_BUFFER_LENGTH        (MAC_STRING_MAX_LENGTH + 1)
+#define SERIAL_NUMBER_BUFFER_LENGTH     (COMPUTER_INFO_QR_MAX_DATA_LENGTH + 1)
+#define UNKNOWN_STRING                  "UNKNOWN"
+
+STATIC
+BOOLEAN
+IsAsciiSpaceCharacter(
+  IN CHAR8 Character
+  )
+{
+  switch (Character) {
+    case ' ':
+    case '\t':
+    case '\n':
+    case '\r':
+    case '\f':
+    case '\v':
+      return TRUE;
+    default:
+      return FALSE;
+  }
+}
 
 STATIC
 VOID
-PrepareVendorString(
-  OUT CHAR8       *Buffer,
-  IN  UINTN        BufferSize,
-  IN  CONST CHAR16 *Vendor
+TrimAndSanitizeSerialNumber(
+  IN OUT CHAR8 *Serial
   )
 {
-  if (BufferSize == 0) {
+  if (Serial == NULL) {
     return;
   }
 
-  if (Vendor == NULL) {
-    AsciiStrCpyS(Buffer, BufferSize, "UNK");
-    return;
+  CHAR8 *Start = Serial;
+  while ((*Start != '\0') && IsAsciiSpaceCharacter(*Start)) {
+    Start++;
   }
 
-  RETURN_STATUS ConversionStatus = UnicodeStrToAsciiStrS(Vendor, Buffer, BufferSize);
-  if (RETURN_ERROR(ConversionStatus)) {
-    AsciiStrnCpyS(Buffer, BufferSize, "UNK", BufferSize - 1);
+  CHAR8 *End = Start + AsciiStrLen(Start);
+  while ((End > Start) && IsAsciiSpaceCharacter(*(End - 1))) {
+    End--;
   }
 
-  for (UINTN Index = 0; Buffer[Index] != '\0'; Index++) {
-    if (Buffer[Index] == ' ') {
-      Buffer[Index] = '_';
+  UINTN Length = (UINTN)(End - Start);
+  if (Length == 0) {
+    Serial[0] = '\0';
+  } else {
+    if (Start != Serial) {
+      CopyMem(Serial, Start, Length);
+    }
+    Serial[Length] = '\0';
+  }
+
+  for (UINTN Index = 0; Serial[Index] != '\0'; Index++) {
+    if (Serial[Index] == '|') {
+      Serial[Index] = '_';
+    } else if ((Serial[Index] < ' ') || (Serial[Index] > '~')) {
+      Serial[Index] = '_';
     }
   }
 }
 
 STATIC
-EFI_STATUS
-GetMemoryStatistics(
-  OUT UINT64 *TotalMemoryMb,
-  OUT UINTN  *DescriptorCount
+VOID
+CopySmbiosString(
+  OUT CHAR8                     *Destination,
+  IN  UINTN                      DestinationSize,
+  IN  CONST SMBIOS_STRUCTURE    *Header,
+  IN  UINTN                      StringNumber
   )
 {
-  if (TotalMemoryMb == NULL || DescriptorCount == NULL) {
-    return EFI_INVALID_PARAMETER;
+  if (DestinationSize == 0) {
+    return;
   }
 
-  EFI_STATUS            Status;
-  EFI_MEMORY_DESCRIPTOR *MemoryMap = NULL;
-  UINTN                 MapSize = 0;
-  UINTN                 MapKey;
-  UINTN                 DescriptorSize = 0;
-  UINT32                DescriptorVersion;
+  Destination[0] = '\0';
 
-  Status = gBS->GetMemoryMap(&MapSize, MemoryMap, &MapKey, &DescriptorSize, &DescriptorVersion);
-  if (Status != EFI_BUFFER_TOO_SMALL) {
-    return Status;
+  if ((Header == NULL) || (StringNumber == 0)) {
+    return;
   }
 
-  MapSize += DescriptorSize * 4;
-  MemoryMap = AllocateZeroPool(MapSize);
-  if (MemoryMap == NULL) {
-    return EFI_OUT_OF_RESOURCES;
+  CONST CHAR8 *Current = (CONST CHAR8 *)Header + Header->Length;
+  UINTN        Index   = 1;
+
+  while ((Index < StringNumber) && (*Current != '\0')) {
+    UINTN Length = AsciiStrLen(Current);
+    Current      += Length + 1;
+    Index++;
   }
 
-  Status = gBS->GetMemoryMap(&MapSize, MemoryMap, &MapKey, &DescriptorSize, &DescriptorVersion);
+  if ((Index != StringNumber) || (*Current == '\0')) {
+    return;
+  }
+
+  AsciiStrnCpyS(Destination, DestinationSize, Current, DestinationSize - 1);
+}
+
+STATIC
+BOOLEAN
+IsValidUuid(
+  IN CONST EFI_GUID *Guid
+  )
+{
+  if (Guid == NULL) {
+    return FALSE;
+  }
+
+  CONST UINT8 *Bytes    = (CONST UINT8 *)Guid;
+  BOOLEAN      AllZero  = TRUE;
+  BOOLEAN      AllOnes  = TRUE;
+
+  for (UINTN Index = 0; Index < sizeof(EFI_GUID); Index++) {
+    if (Bytes[Index] != 0x00) {
+      AllZero = FALSE;
+    }
+    if (Bytes[Index] != 0xFF) {
+      AllOnes = FALSE;
+    }
+  }
+
+  return !(AllZero || AllOnes);
+}
+
+STATIC
+VOID
+GetSystemUuidAndSerial(
+  OUT EFI_GUID *SystemUuid,
+  OUT CHAR8    *SerialNumber,
+  IN  UINTN     SerialBufferLength
+  )
+{
+  if (SystemUuid != NULL) {
+    ZeroMem(SystemUuid, sizeof(EFI_GUID));
+  }
+
+  if ((SerialNumber != NULL) && (SerialBufferLength > 0)) {
+    SerialNumber[0] = '\0';
+  }
+
+  EFI_SMBIOS_PROTOCOL *Smbios;
+  EFI_STATUS           Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID **)&Smbios);
   if (EFI_ERROR(Status)) {
-    FreePool(MemoryMap);
-    return Status;
+    return;
   }
 
-  UINT64 TotalPages = 0;
-  UINTN  Count = MapSize / DescriptorSize;
-  EFI_MEMORY_DESCRIPTOR *Descriptor = MemoryMap;
-  for (UINTN Index = 0; Index < Count; Index++) {
-    TotalPages += Descriptor->NumberOfPages;
-    Descriptor = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)Descriptor + DescriptorSize);
+  EFI_SMBIOS_HANDLE       Handle = SMBIOS_HANDLE_PI_RESERVED;
+  EFI_SMBIOS_TYPE         Type;
+  EFI_SMBIOS_TABLE_HEADER *Record;
+
+  while (TRUE) {
+    Status = Smbios->GetNext(Smbios, &Handle, &Type, &Record, NULL);
+    if (EFI_ERROR(Status)) {
+      break;
+    }
+
+    if (Type == SMBIOS_TYPE_SYSTEM_INFORMATION) {
+      SMBIOS_TABLE_TYPE1 *Type1 = (SMBIOS_TABLE_TYPE1 *)Record;
+      if (SystemUuid != NULL) {
+        CopyMem(SystemUuid, &Type1->Uuid, sizeof(EFI_GUID));
+      }
+
+      if ((SerialNumber != NULL) && (SerialBufferLength > 0)) {
+        CopySmbiosString(SerialNumber, SerialBufferLength, (SMBIOS_STRUCTURE *)Record, Type1->SerialNumber);
+      }
+      break;
+    }
+  }
+}
+
+STATIC
+VOID
+GetPrimaryMacAddress(
+  OUT EFI_MAC_ADDRESS *MacAddress,
+  OUT UINTN           *AddressSize
+  )
+{
+  if (MacAddress != NULL) {
+    ZeroMem(MacAddress, sizeof(EFI_MAC_ADDRESS));
   }
 
-  FreePool(MemoryMap);
+  if (AddressSize != NULL) {
+    *AddressSize = 0;
+  }
 
-  *TotalMemoryMb = DivU64x32(TotalPages, 256);
-  *DescriptorCount = Count;
+  if ((MacAddress == NULL) || (AddressSize == NULL)) {
+    return;
+  }
 
-  return EFI_SUCCESS;
+  EFI_STATUS Status;
+  EFI_HANDLE *HandleBuffer = NULL;
+  UINTN       HandleCount  = 0;
+
+  Status = gBS->LocateHandleBuffer(ByProtocol, &gEfiSimpleNetworkProtocolGuid, NULL, &HandleCount, &HandleBuffer);
+  if (EFI_ERROR(Status) || (HandleCount == 0) || (HandleBuffer == NULL)) {
+    return;
+  }
+
+  BOOLEAN Found = FALSE;
+
+  for (UINTN Index = 0; Index < HandleCount; Index++) {
+    EFI_SIMPLE_NETWORK_PROTOCOL *Snp = NULL;
+    Status = gBS->HandleProtocol(HandleBuffer[Index], &gEfiSimpleNetworkProtocolGuid, (VOID **)&Snp);
+    if (EFI_ERROR(Status) || (Snp == NULL) || (Snp->Mode == NULL)) {
+      continue;
+    }
+
+    UINTN HwAddressSize = Snp->Mode->HwAddressSize;
+    if ((HwAddressSize == 0) || (HwAddressSize > MAC_ADDRESS_MAX_BYTES)) {
+      continue;
+    }
+
+    CopyMem(MacAddress, &Snp->Mode->PermanentAddress, sizeof(EFI_MAC_ADDRESS));
+    *AddressSize = HwAddressSize;
+
+    BOOLEAN NonZero = FALSE;
+    for (UINTN ByteIndex = 0; ByteIndex < HwAddressSize; ByteIndex++) {
+      if (MacAddress->Addr[ByteIndex] != 0x00) {
+        NonZero = TRUE;
+        break;
+      }
+    }
+
+    if (!NonZero) {
+      CopyMem(MacAddress, &Snp->Mode->CurrentAddress, sizeof(EFI_MAC_ADDRESS));
+      for (UINTN ByteIndex = 0; ByteIndex < HwAddressSize; ByteIndex++) {
+        if (MacAddress->Addr[ByteIndex] != 0x00) {
+          NonZero = TRUE;
+          break;
+        }
+      }
+    }
+
+    if (NonZero) {
+      Found = TRUE;
+      break;
+    }
+
+    *AddressSize = 0;
+  }
+
+  if (!Found) {
+    ZeroMem(MacAddress, sizeof(EFI_MAC_ADDRESS));
+  }
+
+  if (HandleBuffer != NULL) {
+    FreePool(HandleBuffer);
+  }
+}
+
+STATIC
+VOID
+GuidToString(
+  IN  CONST EFI_GUID *Guid,
+  OUT CHAR8          *Buffer,
+  IN  UINTN           BufferSize
+  )
+{
+  if ((Buffer == NULL) || (BufferSize == 0)) {
+    return;
+  }
+
+  Buffer[0] = '\0';
+
+  if (Guid == NULL) {
+    return;
+  }
+
+  if (BufferSize < UUID_STRING_BUFFER_LENGTH) {
+    return;
+  }
+
+  AsciiSPrint(
+    Buffer,
+    BufferSize,
+    "%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+    Guid->Data1,
+    Guid->Data2,
+    Guid->Data3,
+    Guid->Data4[0],
+    Guid->Data4[1],
+    Guid->Data4[2],
+    Guid->Data4[3],
+    Guid->Data4[4],
+    Guid->Data4[5],
+    Guid->Data4[6],
+    Guid->Data4[7]
+    );
+}
+
+STATIC
+VOID
+MacAddressToString(
+  IN  CONST EFI_MAC_ADDRESS *MacAddress,
+  IN  UINTN                  AddressSize,
+  OUT CHAR8                 *Buffer,
+  IN  UINTN                  BufferSize
+  )
+{
+  if ((Buffer == NULL) || (BufferSize == 0)) {
+    return;
+  }
+
+  Buffer[0] = '\0';
+
+  if ((MacAddress == NULL) || (AddressSize == 0)) {
+    return;
+  }
+
+  if (BufferSize < (AddressSize * 2 + 1)) {
+    return;
+  }
+
+  UINTN Offset = 0;
+  for (UINTN Index = 0; Index < AddressSize; Index++) {
+    AsciiSPrint(Buffer + Offset, BufferSize - Offset, "%02X", MacAddress->Addr[Index]);
+    Offset += 2;
+  }
 }
 
 STATIC
@@ -119,7 +363,7 @@ RenderQrRow(
   )
 {
   CHAR16 RowBuffer[(COMPUTER_INFO_QR_SIZE + (QUIET_ZONE_SIZE * 2)) * 2 + 1];
-  UINTN Position = 0;
+  UINTN  Position = 0;
 
   for (UINTN Index = 0; Index < QUIET_ZONE_SIZE; Index++) {
     RowBuffer[Position++] = L' ';
@@ -204,79 +448,14 @@ WaitForKeyPress(
 STATIC
 VOID
 ShowQrScreen(
-  IN CONST COMPUTER_INFO_QR_CODE *QrCode,
-  IN CONST CHAR8                 *InfoBuffer
+  IN CONST COMPUTER_INFO_QR_CODE *QrCode
   )
 {
   if (gST->ConOut != NULL) {
     gST->ConOut->ClearScreen(gST->ConOut);
   }
 
-  Print(L"Computer information encoded as QR code:\n\n");
   RenderQrCode(QrCode);
-  Print(L"\nRaw data: %a\n", InfoBuffer);
-}
-
-STATIC
-EFI_STATUS
-ShowMenu(
-  IN CONST COMPUTER_INFO_QR_CODE *QrCode,
-  IN CONST CHAR8                 *InfoBuffer
-  )
-{
-  if ((gST == NULL) || (gST->ConOut == NULL)) {
-    return EFI_UNSUPPORTED;
-  }
-
-  EFI_STATUS    Status;
-  EFI_INPUT_KEY Selection;
-
-  while (TRUE) {
-    gST->ConOut->ClearScreen(gST->ConOut);
-
-    Print(L"Computer Information Menu\n\n");
-    Print(L"Encoded data: %a\n\n", InfoBuffer);
-    Print(L"Options:\n");
-    Print(L"  [1] Display the QR code\n");
-    Print(L"  [Q] Quit\n\n");
-    Print(L"Select an option: ");
-
-    Status = WaitForKeyPress(&Selection);
-    if (EFI_ERROR(Status)) {
-      Print(L"\nFailed to read input: %r\n", Status);
-      return Status;
-    }
-
-    Print(L"\n");
-
-    if (Selection.UnicodeChar == L'1') {
-      ShowQrScreen(QrCode, InfoBuffer);
-      Print(L"\nPress any key to return to the menu...\n");
-      Status = WaitForKeyPress(NULL);
-      if (EFI_ERROR(Status)) {
-        Print(L"Failed to read input: %r\n", Status);
-        return Status;
-      }
-
-      continue;
-    }
-
-    if ((Selection.UnicodeChar == L'Q') || (Selection.UnicodeChar == L'q') || (Selection.ScanCode == SCAN_ESC)) {
-      Print(L"Exiting application...\n");
-      break;
-    }
-
-    Print(L"Unrecognized selection.\n");
-    Print(L"Press any key to try again...\n");
-
-    Status = WaitForKeyPress(NULL);
-    if (EFI_ERROR(Status)) {
-      Print(L"Failed to read input: %r\n", Status);
-      return Status;
-    }
-  }
-
-  return EFI_SUCCESS;
 }
 
 EFI_STATUS
@@ -286,65 +465,56 @@ UefiMain(
   IN EFI_SYSTEM_TABLE *SystemTable
   )
 {
-  EFI_STATUS Status;
-  CHAR8     Vendor[VENDOR_MAX_LENGTH + 1];
-  CHAR8     InfoBuffer[INFO_BUFFER_LENGTH];
-  UINT64    TotalMemoryMb;
-  UINTN     DescriptorCount;
+  EFI_GUID        SystemUuid;
+  CHAR8           SerialNumber[SERIAL_NUMBER_BUFFER_LENGTH];
+  EFI_MAC_ADDRESS MacAddress;
+  UINTN           MacAddressSize;
 
-  SetMem(Vendor, sizeof(Vendor), 0);
-  PrepareVendorString(Vendor, sizeof(Vendor), gST->FirmwareVendor);
-
-  Status = GetMemoryStatistics(&TotalMemoryMb, &DescriptorCount);
-  if (EFI_ERROR(Status)) {
-    Print(L"Failed to retrieve memory information: %r\n", Status);
-    return Status;
+  GetSystemUuidAndSerial(&SystemUuid, SerialNumber, sizeof(SerialNumber));
+  TrimAndSanitizeSerialNumber(SerialNumber);
+  if (SerialNumber[0] == '\0') {
+    AsciiStrCpyS(SerialNumber, sizeof(SerialNumber), UNKNOWN_STRING);
   }
 
-  if (TotalMemoryMb > 99999) {
-    TotalMemoryMb = 99999;
+  GetPrimaryMacAddress(&MacAddress, &MacAddressSize);
+
+  CHAR8 UuidString[UUID_STRING_BUFFER_LENGTH];
+  if (IsValidUuid(&SystemUuid)) {
+    GuidToString(&SystemUuid, UuidString, sizeof(UuidString));
+  } else {
+    AsciiStrCpyS(UuidString, sizeof(UuidString), UNKNOWN_STRING);
   }
 
-  if (DescriptorCount > 999) {
-    DescriptorCount = 999;
+  CHAR8 MacString[MAC_STRING_BUFFER_LENGTH];
+  MacAddressToString(&MacAddress, MacAddressSize, MacString, sizeof(MacString));
+  if (MacString[0] == '\0') {
+    AsciiStrCpyS(MacString, sizeof(MacString), UNKNOWN_STRING);
   }
 
-  AsciiSPrint(
-    InfoBuffer,
-    sizeof(InfoBuffer),
-    "V:%a|R:%08X|M:%05Lu|D:%03u",
-    Vendor,
-    gST->FirmwareRevision,
-    TotalMemoryMb,
-    (UINT32)DescriptorCount
-    );
+  UINTN SerialLength = AsciiStrLen(SerialNumber);
+  UINTN UuidLength   = AsciiStrLen(UuidString);
+  UINTN MacLength    = AsciiStrLen(MacString);
+  if ((UuidLength + 1 + MacLength + 1 + SerialLength) > COMPUTER_INFO_QR_MAX_DATA_LENGTH) {
+    Print(L"Encoded data is too large for the selected QR code size.\n");
+    return EFI_BAD_BUFFER_SIZE;
+  }
 
-  InfoBuffer[COMPUTER_INFO_QR_MAX_DATA_LENGTH] = '\0';
+  CHAR8 InfoBuffer[INFO_BUFFER_LENGTH];
+  AsciiSPrint(InfoBuffer, sizeof(InfoBuffer), "%a|%a|%a", UuidString, MacString, SerialNumber);
   UINTN DataLength = AsciiStrLen(InfoBuffer);
-  if (DataLength > COMPUTER_INFO_QR_MAX_DATA_LENGTH) {
-    DataLength = COMPUTER_INFO_QR_MAX_DATA_LENGTH;
+  if ((DataLength == 0) || (DataLength > COMPUTER_INFO_QR_MAX_DATA_LENGTH)) {
+    return EFI_BAD_BUFFER_SIZE;
   }
 
   COMPUTER_INFO_QR_CODE QrCode;
-  Status = GenerateComputerInfoQrCode((CONST UINT8 *)InfoBuffer, DataLength, &QrCode);
+  EFI_STATUS            Status = GenerateComputerInfoQrCode((CONST UINT8 *)InfoBuffer, DataLength, &QrCode);
   if (EFI_ERROR(Status)) {
     Print(L"QR code generation failed: %r\n", Status);
     return Status;
   }
 
-  ShowQrScreen(&QrCode, InfoBuffer);
-
-  Print(L"\nPress any key to continue...\n");
-  Status = WaitForKeyPress(NULL);
-  if (EFI_ERROR(Status)) {
-    Print(L"Failed to read input: %r\n", Status);
-    return Status;
-  }
-
-  Status = ShowMenu(&QrCode, InfoBuffer);
-  if (EFI_ERROR(Status)) {
-    return Status;
-  }
+  ShowQrScreen(&QrCode);
+  WaitForKeyPress(NULL);
 
   return EFI_SUCCESS;
 }

--- a/ComputerInfoQrPkg/Application/QrCode.c
+++ b/ComputerInfoQrPkg/Application/QrCode.c
@@ -5,9 +5,9 @@
 
 #define QR_VERSION                    COMPUTER_INFO_QR_VERSION
 #define QR_SIZE_PIXELS                COMPUTER_INFO_QR_SIZE
-#define QR_DATA_CODEWORDS             34
-#define QR_ECC_CODEWORDS              10
-#define QR_TOTAL_CODEWORDS            44
+#define QR_DATA_CODEWORDS             108
+#define QR_ECC_CODEWORDS              26
+#define QR_TOTAL_CODEWORDS            134
 #define QR_REMAINDER_BITS             7
 #define QR_DATA_BIT_CAPACITY          (QR_DATA_CODEWORDS * 8)
 

--- a/ComputerInfoQrPkg/Application/QrCode.h
+++ b/ComputerInfoQrPkg/Application/QrCode.h
@@ -3,9 +3,9 @@
 
 #include <Uefi.h>
 
-#define COMPUTER_INFO_QR_VERSION             2
+#define COMPUTER_INFO_QR_VERSION             5
 #define COMPUTER_INFO_QR_SIZE                (4 * COMPUTER_INFO_QR_VERSION + 17)
-#define COMPUTER_INFO_QR_MAX_DATA_LENGTH     32
+#define COMPUTER_INFO_QR_MAX_DATA_LENGTH     108
 
 typedef struct {
   UINTN Size;


### PR DESCRIPTION
## Summary
- retrieve the system UUID, serial number, and primary MAC address to build the QR payload and render only the QR code on screen
- raise the QR code version to allow the larger payload required for the identifiers

## Testing
- not run (UEFI build environment unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68c89f8278a48321965cfe553b73d900