### PR TITLE
Add menu and HTTPS posting via DHCP-configured server

### DIFF
--- a/ComputerInfoQrPkg/Application/ComputerInfoQrApp.inf
+++ b/ComputerInfoQrPkg/Application/ComputerInfoQrApp.inf
@@ -34,5 +34,8 @@
 
 [Protocols]
   gEfiGraphicsOutputProtocolGuid
+  gEfiDhcp4ProtocolGuid
+  gEfiHttpProtocolGuid
+  gEfiHttpServiceBindingProtocolGuid
   gEfiSimpleNetworkProtocolGuid
   gEfiSmbiosProtocolGuid


### PR DESCRIPTION
## Summary
- add a text-based menu so users can switch between showing the QR code and invoking network operations
- gather the server URL from a DHCP option and post the system information JSON payload over HTTPS
- declare the additional protocol dependencies required for DHCP and HTTP access

## Testing
- not run (UEFI build/test environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9daabb6588321b349ca4f656aa130