### PR TITLE
Fix HTTP service binding protocol type

### DIFF
--- a/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
+++ b/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
@@ -597,7 +597,7 @@ PostSystemInfoToServer(
   BOOLEAN    Completed = FALSE;
 
   for (UINTN Index = 0; Index < HandleCount; Index++) {
-    EFI_HTTP_SERVICE_BINDING_PROTOCOL *ServiceBinding = NULL;
+    EFI_SERVICE_BINDING_PROTOCOL      *ServiceBinding = NULL;
     EFI_HANDLE                         ChildHandle    = NULL;
     EFI_HTTP_PROTOCOL                 *Http           = NULL;
     BOOLEAN                            ChildCreated   = FALSE;


### PR DESCRIPTION
## Summary
- use the generic EFI_SERVICE_BINDING_PROTOCOL interface when looking up HTTP service binding handles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9e8040aa48321a64d6346e73f26a5