### PR TITLE
Fix DHCP RenewRebind usage

### DIFF
--- a/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
+++ b/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
@@ -872,9 +872,9 @@ RenewDhcpLeaseOnHandle(
     return EFI_UNSUPPORTED;
   }
 
-  Status = Dhcp4->RenewRebind(Dhcp4, FALSE);
+  Status = Dhcp4->RenewRebind(Dhcp4, FALSE, NULL);
   if (Status == EFI_NO_MAPPING) {
-    Status = Dhcp4->RenewRebind(Dhcp4, TRUE);
+    Status = Dhcp4->RenewRebind(Dhcp4, TRUE, NULL);
   }
 
   return Status;


### PR DESCRIPTION
## Summary
- pass a NULL completion token when invoking `EFI_DHCP4_PROTOCOL.RenewRebind`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbf850fa5c83219437896c91a990fe