### PR TITLE
Fix IsValidUuid forward declaration

### DIFF
--- a/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
+++ b/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
@@ -49,6 +49,12 @@ InitializeNicOnHandle(
 
 STATIC
 BOOLEAN
+IsValidUuid(
+  IN CONST EFI_GUID *Guid
+  );
+
+STATIC
+BOOLEAN
 IsAsciiSpaceCharacter(
   IN CHAR8 Character
   )


### PR DESCRIPTION
## Summary
- add a forward declaration for IsValidUuid before its first use to avoid implicit-int assumptions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc832e7cd883218008bc4df8e60f4b