### PR TITLE
Declare SMBIOS table GUID dependencies

### DIFF
--- a/ComputerInfoQrPkg/Application/ComputerInfoQrApp.inf
+++ b/ComputerInfoQrPkg/Application/ComputerInfoQrApp.inf
@@ -39,3 +39,7 @@
   gEfiHttpServiceBindingProtocolGuid
   gEfiSimpleNetworkProtocolGuid
   gEfiSmbiosProtocolGuid
+
+[Guids]
+  gEfiSmbiosTableGuid
+  gEfiSmbios3TableGuid


### PR DESCRIPTION
## Summary
- declare gEfiSmbiosTableGuid and gEfiSmbios3TableGuid so the application links the SMBIOS GUID symbols

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc873400a88321bc6b323461bbacda