### PR TITLE
Declare hardware info helper prototypes

### DIFF
--- a/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
+++ b/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
@@ -90,6 +90,33 @@ IsValidUuid(
   );
 
 STATIC
+VOID
+GetCpuInfo(
+  OUT CHAR8 *CpuModel,
+  IN UINTN  CpuModelSize,
+  OUT CHAR8 *CpuSize,
+  IN UINTN  CpuSizeSize
+  );
+
+STATIC
+VOID
+GetBaseboardInfo(
+  OUT CHAR8 *BoardModel,
+  IN UINTN  BoardModelSize,
+  OUT CHAR8 *BoardSize,
+  IN UINTN  BoardSizeSize
+  );
+
+STATIC
+VOID
+GetMemoryInfo(
+  OUT CHAR8 *MemoryModel,
+  IN UINTN  MemoryModelSize,
+  OUT CHAR8 *MemorySize,
+  IN UINTN  MemorySizeSize
+  );
+
+STATIC
 BOOLEAN
 IsAsciiSpaceCharacter(
   IN CHAR8 Character


### PR DESCRIPTION
## Summary
- declare static prototypes for GetCpuInfo, GetBaseboardInfo, and GetMemoryInfo
- prevent implicit function declaration warnings when compiling ComputerInfoQrApp

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdd9b896dc83219acbca563ad3b91e