### PR TITLE
Support 16-bit QR payload length fields

### DIFF
--- a/tests/stubs/Library/BaseLib.h
+++ b/tests/stubs/Library/BaseLib.h
@@ -1,0 +1,6 @@
+#ifndef TESTS_STUBS_LIBRARY_BASELIB_H_
+#define TESTS_STUBS_LIBRARY_BASELIB_H_
+
+#include "../Uefi.h"
+
+#endif  // TESTS_STUBS_LIBRARY_BASELIB_H_

--- a/tests/stubs/Library/BaseMemoryLib.h
+++ b/tests/stubs/Library/BaseMemoryLib.h
@@ -1,0 +1,36 @@
+#ifndef TESTS_STUBS_LIBRARY_BASEMEMORYLIB_H_
+#define TESTS_STUBS_LIBRARY_BASEMEMORYLIB_H_
+
+#include "../Uefi.h"
+#include <string.h>
+
+STATIC inline VOID *
+CopyMem(
+  OUT VOID       *Destination,
+  IN  CONST VOID *Source,
+  IN  UINTN       Length
+  )
+{
+  return memcpy(Destination, Source, Length);
+}
+
+STATIC inline VOID *
+SetMem(
+  OUT VOID *Buffer,
+  IN  UINTN Length,
+  IN  UINT8 Value
+  )
+{
+  return memset(Buffer, Value, Length);
+}
+
+STATIC inline VOID *
+ZeroMem(
+  OUT VOID *Buffer,
+  IN  UINTN Length
+  )
+{
+  return memset(Buffer, 0, Length);
+}
+
+#endif  // TESTS_STUBS_LIBRARY_BASEMEMORYLIB_H_

--- a/tests/stubs/Library/MemoryAllocationLib.h
+++ b/tests/stubs/Library/MemoryAllocationLib.h
@@ -1,0 +1,23 @@
+#ifndef TESTS_STUBS_LIBRARY_MEMORYALLOCATIONLIB_H_
+#define TESTS_STUBS_LIBRARY_MEMORYALLOCATIONLIB_H_
+
+#include "../Uefi.h"
+#include <stdlib.h>
+
+STATIC inline VOID *
+AllocateZeroPool(
+  IN UINTN AllocationSize
+  )
+{
+  return (AllocationSize == 0) ? NULL : calloc(1, AllocationSize);
+}
+
+STATIC inline VOID
+FreePool(
+  IN VOID *Buffer
+  )
+{
+  free(Buffer);
+}
+
+#endif  // TESTS_STUBS_LIBRARY_MEMORYALLOCATIONLIB_H_

--- a/tests/stubs/Uefi.h
+++ b/tests/stubs/Uefi.h
@@ -1,0 +1,42 @@
+#ifndef TESTS_STUBS_UEFI_H_
+#define TESTS_STUBS_UEFI_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define IN
+#define OUT
+#define OPTIONAL
+#define CONST const
+#define STATIC static
+
+typedef void     VOID;
+typedef uint8_t  BOOLEAN;
+typedef int8_t   INT8;
+typedef uint8_t  UINT8;
+typedef int16_t  INT16;
+typedef uint16_t UINT16;
+typedef int32_t  INT32;
+typedef uint32_t UINT32;
+typedef int64_t  INT64;
+typedef uint64_t UINT64;
+typedef size_t   UINTN;
+typedef long     INTN;
+
+typedef UINT64 EFI_STATUS;
+
+#define TRUE  ((BOOLEAN)1)
+#define FALSE ((BOOLEAN)0)
+
+#define EFI_SUCCESS           0ULL
+#define EFI_INVALID_PARAMETER 2ULL
+#define EFI_BAD_BUFFER_SIZE   3ULL
+#define EFI_BUFFER_TOO_SMALL  4ULL
+#define EFI_OUT_OF_RESOURCES  5ULL
+
+#define EFI_ERROR(Status) ((Status) != EFI_SUCCESS)
+
+#define MAX_INT32  0x7FFFFFFF
+#define ABS(Value) (((Value) < 0) ? -(Value) : (Value))
+
+#endif  // TESTS_STUBS_UEFI_H_

--- a/tests/test_qr_payload_length.c
+++ b/tests/test_qr_payload_length.c
@@ -1,0 +1,135 @@
+#include "stubs/Uefi.h"
+#include "stubs/Library/BaseMemoryLib.h"
+#include "stubs/Library/BaseLib.h"
+#include "stubs/Library/MemoryAllocationLib.h"
+
+#include "../ComputerInfoQrPkg/Application/QrCode.c"
+
+#include <stdio.h>
+
+static UINTN
+DetermineVersionForPayload(
+  UINTN PayloadLength,
+  UINTN *DataCapacity
+  )
+{
+  for (UINTN Version = COMPUTER_INFO_QR_MIN_VERSION; Version <= COMPUTER_INFO_QR_MAX_VERSION; Version++) {
+    UINTN Capacity = GetDataCodewordCapacity(Version);
+    if (Capacity == 0) {
+      continue;
+    }
+
+    UINTN CharCountBits = (Version <= 9) ? 8 : 16;
+    if ((CharCountBits == 8) && (PayloadLength > 0xFF)) {
+      continue;
+    }
+
+    if (PayloadLength <= Capacity) {
+      if (DataCapacity != NULL) {
+        *DataCapacity = Capacity;
+      }
+      return Version;
+    }
+  }
+
+  if (DataCapacity != NULL) {
+    *DataCapacity = 0;
+  }
+  return 0;
+}
+
+static int
+TestBuildDataCodewordsUsesSixteenBitLength(void)
+{
+  const UINTN PayloadLength = 300;
+  UINT8 Payload[PayloadLength];
+  for (UINTN Index = 0; Index < PayloadLength; Index++) {
+    Payload[Index] = (UINT8)(Index & 0xFF);
+  }
+
+  UINT8 Codewords[COMPUTER_INFO_QR_MAX_PAYLOAD_LENGTH];
+  UINTN DataCapacity = 0;
+  UINTN Version = DetermineVersionForPayload(PayloadLength, &DataCapacity);
+  if ((Version == 0) || (DataCapacity == 0)) {
+    fprintf(stderr, "Unable to determine QR version for payload length %zu\n", PayloadLength);
+    return 1;
+  }
+
+  UINTN CharCountBits = (Version <= 9) ? 8 : 16;
+  if (CharCountBits != 16) {
+    fprintf(stderr, "Expected to use 16-bit length field for payload %zu but selected version %zu\n", PayloadLength, Version);
+    return 1;
+  }
+
+  EFI_STATUS Status = BuildDataCodewords(Payload, PayloadLength, Codewords, DataCapacity, 8);
+  if (Status != EFI_BAD_BUFFER_SIZE) {
+    fprintf(stderr, "Expected 8-bit length field rejection, got %llu\n", (unsigned long long)Status);
+    return 1;
+  }
+
+  Status = BuildDataCodewords(Payload, PayloadLength, Codewords, DataCapacity, CharCountBits);
+  if (Status != EFI_SUCCESS) {
+    fprintf(stderr, "Expected success for 16-bit length field, got %llu\n", (unsigned long long)Status);
+    return 1;
+  }
+
+  UINT8 ExpectedByte0 = (UINT8)(0x40 | ((PayloadLength >> 12) & 0x0F));
+  UINT8 ExpectedByte1 = (UINT8)((PayloadLength >> 4) & 0xFF);
+  UINT8 ExpectedByte2High = (UINT8)((PayloadLength & 0x0F) << 4);
+
+  if (Codewords[0] != ExpectedByte0) {
+    fprintf(stderr, "Unexpected mode/length byte: got 0x%02X expected 0x%02X\n", Codewords[0], ExpectedByte0);
+    return 1;
+  }
+
+  if (Codewords[1] != ExpectedByte1) {
+    fprintf(stderr, "Unexpected high length byte: got 0x%02X expected 0x%02X\n", Codewords[1], ExpectedByte1);
+    return 1;
+  }
+
+  if ((Codewords[2] & 0xF0) != ExpectedByte2High) {
+    fprintf(stderr, "Unexpected low length nibble: got 0x%02X expected 0x%02X\n", Codewords[2] & 0xF0, ExpectedByte2High);
+    return 1;
+  }
+
+  return 0;
+}
+
+static int
+TestGenerateComputerInfoQrCodeSelectsCorrectVersion(void)
+{
+  const UINTN PayloadLength = 300;
+  UINT8 Payload[PayloadLength];
+  for (UINTN Index = 0; Index < PayloadLength; Index++) {
+    Payload[Index] = (UINT8)(Index & 0xFF);
+  }
+
+  COMPUTER_INFO_QR_CODE QrCode;
+  EFI_STATUS Status = GenerateComputerInfoQrCode(Payload, PayloadLength, &QrCode);
+  if (Status != EFI_SUCCESS) {
+    fprintf(stderr, "GenerateComputerInfoQrCode failed with %llu\n", (unsigned long long)Status);
+    return 1;
+  }
+
+  UINTN DerivedVersion = (QrCode.Size - 17) / 4;
+  if (DerivedVersion <= 9) {
+    fprintf(stderr, "Expected QR version >= 10 for payload >255 bytes, got %zu\n", DerivedVersion);
+    return 1;
+  }
+
+  return 0;
+}
+
+int
+main(void)
+{
+  if (TestBuildDataCodewordsUsesSixteenBitLength() != 0) {
+    return 1;
+  }
+
+  if (TestGenerateComputerInfoQrCodeSelectsCorrectVersion() != 0) {
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- allow BuildDataCodewords to emit either 8- or 16-bit length fields and validate the provided width
- require GenerateComputerInfoQrCode to promote payloads over 255 bytes to the 16-bit length path and pass the width through
- add a host-side regression test with stubbed UEFI headers to cover the 16-bit length handling

## Testing
- `gcc -std=c11 -Wall -Wextra -I tests/stubs tests/test_qr_payload_length.c -o tests/test_qr_payload_length`
- `tests/test_qr_payload_length`


------
https://chatgpt.com/codex/tasks/task_e_68ce4cd20ab08321aa6b5c0f95af2e2b