### PR TITLE
Define PCI header type device if missing

### DIFF
--- a/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
+++ b/ComputerInfoQrPkg/Application/ComputerInfoQrApp.c
@@ -21,6 +21,10 @@
 
 #include "QrCode.h"
 
+#ifndef PCI_HEADER_TYPE_DEVICE
+#define PCI_HEADER_TYPE_DEVICE 0x00
+#endif
+
 #define QUIET_ZONE_SIZE                 2
 #define JSON_PAYLOAD_BUFFER_LENGTH      (COMPUTER_INFO_QR_MAX_PAYLOAD_LENGTH + 1)
 #define HARDWARE_MODEL_BUFFER_LENGTH    128


### PR DESCRIPTION
## Summary
- define `PCI_HEADER_TYPE_DEVICE` when the industry standard header does not provide it

## Testing
- not run (UEFI build environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf028d056c8321b6a669d061448df1