### PR TITLE
Declare dependency on PCI IO protocol

### DIFF
--- a/ComputerInfoQrPkg/Application/ComputerInfoQrApp.inf
+++ b/ComputerInfoQrPkg/Application/ComputerInfoQrApp.inf
@@ -38,6 +38,7 @@
   gEfiHttpProtocolGuid
   gEfiHttpServiceBindingProtocolGuid
   gEfiSimpleNetworkProtocolGuid
+  gEfiPciIoProtocolGuid
   gEfiSmbiosProtocolGuid
 
 [Guids]


### PR DESCRIPTION
## Summary
- declare gEfiPciIoProtocolGuid in the application's [Protocols] section so the GUID is linked

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf039711ac832193b74d9edb7a6f5a